### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/src/main/java/com/example/boogle/MainActivity.kt
+++ b/app/src/main/java/com/example/boogle/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.example.boogle.data.BookDatabase
 import com.example.boogle.data.Books
@@ -31,7 +33,8 @@ class MainActivity : ComponentActivity() {
                 bookDatabase?.bookDao())
             val vm = BookViewModel(bookRepository)
             vm.getBooksList()
-            BoogleTheme {
+            var darkTheme by remember { mutableStateOf(false) }
+            BoogleTheme(darkTheme = darkTheme) {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
@@ -55,7 +58,9 @@ class MainActivity : ComponentActivity() {
                             searchQuery = {
                                 vm.onEvent(Events.Search(query = it))
                             },
-                            searchResponse
+                            searchResponse = searchResponse,
+                            darkTheme = darkTheme,
+                            onToggleTheme = { darkTheme = !darkTheme }
                         )
                     }
                 }

--- a/app/src/main/java/com/example/boogle/screens/Search.kt
+++ b/app/src/main/java/com/example/boogle/screens/Search.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Search
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
 
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
@@ -31,7 +32,9 @@ import com.example.boogle.data.Books
 @Composable
 fun Search(
     searchQuery: (text: String) -> Unit,
-    searchResponse: MutableState<List<Books>>
+    searchResponse: MutableState<List<Books>>,
+    darkTheme: Boolean,
+    onToggleTheme: () -> Unit
 ){
 
     Column( modifier = Modifier.fillMaxSize()) {
@@ -40,6 +43,7 @@ fun Search(
             modifier = Modifier.padding(10.dp)
         ) {
             SearchBart(searchQuery)
+            Switch(checked = darkTheme, onCheckedChange = { onToggleTheme() })
         }
 
         LazyColumn{


### PR DESCRIPTION
## Summary
- toggle theme in `MainActivity` and propagate to `Search`
- add a `Switch` in search bar to flip dark mode

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecdbde8c8832aa85713b12b4a2f3b